### PR TITLE
add new features and fix random-datasource proof verification

### DIFF
--- a/eos_api.hpp
+++ b/eos_api.hpp
@@ -18,6 +18,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+#ifndef ORACLIZEAPI_H
+#define ORACLIZEAPI_H
 
 #if __cplusplus < 201103
 #warning "To enable all features you must compile with -std=c++11"
@@ -1119,15 +1121,12 @@ const uint8_t proofType_Android = 0x40;
 const uint8_t proofType_Native = 0xF0;
 const uint8_t proofStorage_IPFS = 0x01;
 
-#ifndef CONSTANTS 
-#define CONSTANTS
 const uint8_t CODE_HASH_RANDOMDS[32] = {
     253, 148, 250, 113, 188, 11, 161, 13, 57, 212, 100, 208, 216, 244, 101, 239, 238, 240, 162, 118, 78, 56, 135, 252, 201, 223, 65, 222, 210, 15, 80, 92
 };
 const uint8_t LEDGERKEY[64] = {
     127, 185, 86, 70, 156, 92, 155, 137, 132, 13, 85, 180, 53, 55, 230, 106, 152, 221, 72, 17, 234, 10, 39, 34, 66, 114, 194, 229, 98, 41, 17, 232, 83, 122, 47, 142, 134, 164, 107, 174, 200, 40, 100, 233, 141, 208, 30, 156, 204, 47, 139, 197, 223, 201, 203, 229, 169, 26, 41, 4, 152, 221, 150, 228
 };
-#endif
 
 
 /**************************************************
@@ -1203,13 +1202,22 @@ typedef eosio::multi_index<name("queryid"), queryid> ds_queryid;
  **************************************************/
 uint64_t oraclize_cbAddress()
 {
-    // go to the connector table which identify the sender 
+    // Go to the connector table which identify the sender
     ds_cbaddr cb_addrs("oraclizeconn"_n, "oraclizeconn"_n.value);
-    // point to the first element of the table: 1. if table is empty 
+    // Point to the first element of the table
     auto itr = cb_addrs.begin();
-
     uint64_t cbaddr = (itr != cb_addrs.end()) ? itr->sender.value : 0;
     return cbaddr;
+}
+
+bool checksum256_is_empty(const capi_checksum256 c)
+{
+    for(int i=0; i<32; i++)
+    {
+        if(c.hash[i] != 0)
+            return false;
+    }
+    return true;
 }
 
 std::string vector_to_string(const std::vector<uint8_t> v)
@@ -1310,8 +1318,9 @@ vector<uint8_t> __oraclize_cbor_encode(const vector<vector<uint8_t>> params)
 capi_checksum256 __oraclize_randomDS_getSessionPubkeyHash()
 {
     ds_spubkey spubkeys("oraclizeconn"_n, "oraclizeconn"_n.value);
-    // just one value in the table with the key=1
-    const auto itr = spubkeys.find(1);
+    // Just one value in the table with the key = 1
+    name index = "1"_n;
+    auto itr = spubkeys.find(index.value);
     capi_checksum256 sessionPubkeyHash;
     if (itr != spubkeys.end())
     {
@@ -1323,7 +1332,7 @@ capi_checksum256 __oraclize_randomDS_getSessionPubkeyHash()
 uint32_t __oraclize_getSenderNonce(name sender)
 {
     ds_snonce last_nonces("oraclizeconn"_n, "oraclizeconn"_n.value);
-    const auto itr = last_nonces.find(sender.value);
+    auto itr = last_nonces.find(sender.value);
     uint32_t nonce = 0;
     if (itr != last_nonces.end())
     {
@@ -1337,7 +1346,7 @@ capi_checksum256 __oraclize_getNextQueryId(const name sender)
     // Get values to generate the queryId
     const uint32_t nonce = __oraclize_getSenderNonce(sender);
     const size_t tx_size = transaction_size();
-    // calculate the hash of the previous values
+    // Calculate the hash of the previous values
     uint8_t tbh[sizeof(sender) + sizeof(nonce) + sizeof(tx_size)];
     std::memcpy(tbh, &sender, sizeof(sender));
     std::memcpy(tbh + sizeof(sender), &nonce, sizeof(nonce));
@@ -1350,42 +1359,39 @@ capi_checksum256 __oraclize_getNextQueryId(const name sender)
 // check that the queryId being passed matches with the one in the customer local table, return true/false accordingly
 bool __oraclize_queryId_match(const capi_checksum256 queryId, const name sender)
 {
-    // retreive the short queryId from the full queryId
+    // Retreive the short queryId from the full queryId
     name myQueryId_short;
     std::memcpy(&myQueryId_short, &queryId.hash, sizeof(myQueryId_short));
-    
-    // access the local table 
-    ds_queryid queryids(sender, sender.value); 
-    const auto itr = queryids.find(myQueryId_short.value);
+    // Access the local query table and find the right row
+    ds_queryid queryids(sender, sender.value);
+    auto itr = queryids.find(myQueryId_short.value);
+    // Get the local queryId value
     capi_checksum256 queryId_expected;
     std::memcpy(&queryId_expected, 0, sizeof(queryId_expected));
+    // Get the queryId from the table
     if (itr != queryids.end())
-    {
         queryId_expected = itr->qid;
-    }
-    
-    // convert queryId and queryId_expecte to string to compare them
-    std::string queryId_str__expected = checksum256_to_string(queryId_expected);
-    std::string queryId_str = checksum256_to_string(queryId);
- 
-    // compare the queryids 
-    if (queryId_str != queryId_str__expected)
-    {
-        return false;
-    }
     else
-    {
+        return false;
+    // Check if the value retrieved is only 0
+    if(checksum256_is_empty(queryId_expected))
+        return false;
+    // Convert queryId and queryId_expected to string, to compare them
+    const std::string queryId_str__expected = checksum256_to_string(queryId_expected);
+    const std::string queryId_str = checksum256_to_string(queryId);
+    // Compare the queryids and check if string values are empty
+    if (queryId_str != queryId_str__expected || queryId_str.empty() || queryId_str__expected.empty())
+        return false;
+    else
         return true;
-    }
 }
 
 void __oraclize_queryId_localEmplace(const capi_checksum256 myQueryId, const name sender)
 {
-    // retreive the short queryId to use it as an index
+    // Retreive the short queryId to use it as an index
     name myQueryId_short;
     std::memcpy(&myQueryId_short, &myQueryId.hash, sizeof(myQueryId_short));
-    
-	// save the queryId in the local table
+    // Save the queryId in the local table
     ds_queryid queryids(sender, sender.value);
     queryids.emplace(sender, [&](auto& o) {
         o.key = myQueryId_short;
@@ -1401,7 +1407,7 @@ void __oraclize_queryId_localEmplace(const capi_checksum256 myQueryId, const nam
  **************************************************/
 capi_checksum256 __oraclize_query(const name user, const unsigned int timestamp, const std::string datasource, const std::string query, const uint8_t prooftype, const name sender)
 {
-    capi_checksum256 queryId = __oraclize_getNextQueryId(sender);
+    const capi_checksum256 queryId = __oraclize_getNextQueryId(sender);
     action(permission_level{user, "active"_n},
         "oraclizeconn"_n, 
         "querystr"_n,
@@ -1434,7 +1440,7 @@ capi_checksum256 __oraclize_query(const name user, const unsigned int timestamp,
 {
     const capi_checksum256 queryId = __oraclize_getNextQueryId(sender);
     printhex(__oraclize_cbor_encode(query).data(), __oraclize_cbor_encode(query).size());
-    const auto n = name{user};
+    auto n = name{user};
     const std::string str = n.to_string();
     action(permission_level{user, "active"_n},
         "oraclizeconn"_n, 
@@ -1469,7 +1475,7 @@ void __oraclize_randomDS_setCommitment(const capi_checksum256 queryId, const cap
     name myQueryId_short; // Calculate the short queryId, to use it as a key of the table
     std::memcpy(&myQueryId_short, &queryId.hash[0], sizeof(myQueryId_short));
     ds_scommitment last_commitments(payer, payer.value); // Set the commitment in the eos table of the caller
-    last_commitments.emplace(payer, [&](auto &o) { //key must be a uint64_t so a short query Id is used
+    last_commitments.emplace(payer, [&](auto &o) { // The key must be a uint64_t so a short query Id is used
         o.shortqueryid = myQueryId_short;
         o.queryid = queryId;
         o.commitment = commitment;
@@ -1513,7 +1519,7 @@ capi_checksum256 __oraclize_newRandomDSQuery(const name user, const uint32_t _de
     // Call the oraclize_query and get the queryId
     const capi_checksum256 queryId = __oraclize_query(user,"random", args, proofType_Ledger, sender); // proofType and datasource are always fixed in this function
     // Calculate the commitment and call a function to set it    
-    std::vector<uint8_t> delayBa(8); // delay converted to  8 byte
+    std::vector<uint8_t> delayBa(8); // delay converted to 8 byte
     delayBa = uint32_to_vector8(delayLedgerTime);
     capi_checksum256 unonceHashBaHash; // unonce has to be passed hashed
     uint8_t* charArray = &unonceHashBa[0];
@@ -1564,7 +1570,7 @@ bool __oraclize_randomDS_test_pubkey_signature(const uint8_t whatever, const uin
     // Discard the first (0x00) and the second byte (0x02 or 0x03)
     return std::memcmp(compressed + 2, pubkey, 32) == 0;
     // Note: eosio doesn't provide a way to decompress the key obtained by recover_key
-    // So here we compress the given pub key (by extracting the relevant x coord)
+    // So, here we compress the given pub key (by extracting the relevant x coord)
     // and then check if it's equal to the one returned by the function
 }
 
@@ -1648,19 +1654,19 @@ uint8_t oraclize_randomDS_proofVerify(const capi_checksum256 queryId, const std:
     sha256((char *)tbh, sizeof(tbh), &lastCommitment);
     // Retrieve the table commitment
     ds_scommitment last_commitments(payer, payer.value);
-    uint64_t myQueryId_short;
+    name myQueryId_short;
     std::memcpy(&myQueryId_short, &queryId.hash[0], sizeof(myQueryId_short));
-    // Check the query id with the one in the table
-    const auto itr = last_commitments.find(myQueryId_short);
-    capi_checksum256 queryId_expected;
+    // Check if the key value exists
+    auto itr = last_commitments.find(myQueryId_short.value);
     if (itr == last_commitments.end())
-        queryId_expected = itr->queryid;
-    const std::string queryId_str__expected = checksum256_to_string(last_commitments.find(myQueryId_short)->queryid);
+        return 4;
+    // Check the query id with the one in the table
+    const std::string queryId_str__expected = checksum256_to_string(itr->queryid);
     const std::string queryId_str = checksum256_to_string(queryId);
     if (queryId_str != queryId_str__expected)
         return 4;
     // Check the commitment with the one in the table
-    const std::string lastCommitment_str__expected = checksum256_to_string(last_commitments.find(myQueryId_short)->commitment);
+    const std::string lastCommitment_str__expected = checksum256_to_string(itr->commitment);
     const std::string lastCommitment_str = checksum256_to_string(lastCommitment);
     if (lastCommitment_str != lastCommitment_str__expected)
         return 4;
@@ -1715,8 +1721,10 @@ uint8_t oraclize_randomDS_proofVerify(const capi_checksum256 queryId, const std:
         return 7;
 
 
-    // Erase the last commitment
-    const auto itr2 = last_commitments.find(myQueryId_short);
+    // Erase the commitment after the proof is verified
+    auto itr2 = last_commitments.find(myQueryId_short.value);
     last_commitments.erase(itr2);
     return 0;
 }
+
+#endif


### PR DESCRIPTION
### What this PR is:

1. Modify **EOS API** for fixing the getter method for the `sesspubkey` in the `oraclizeconn` table
2. Check if `queryIds` are empty before matching them
3. Adding a method that returns true if a `checksum256` is 0

***

### To Do: 

__❍__  @bertani Please, could you carefully review the code before merging it?   

***

### Notes: 

__❍__  I again tested successfully all the `eos-examples` with this PR eos_api version. 

__❍__ I created another branch for a correct `rebase`.